### PR TITLE
add cat 5 typhoon

### DIFF
--- a/IBF-Typhoon-model/src/climada/hazard/tc_tracks.py
+++ b/IBF-Typhoon-model/src/climada/hazard/tc_tracks.py
@@ -79,6 +79,7 @@ CAT_NAMES = {
     2: 'Typhoon', 
     3: 'Severe Typhoon', 
     4: 'Super Typhoon', 
+    5: 'Super Typhoon', 
 
 }
 """Saffir-Simpson category names."""


### PR DESCRIPTION
__Issue:__ Recent IBF typhoon runs often fails at the `set_category` step.
See log: [logic app run](https://portal.azure.com/#view/Microsoft_Azure_EMA/LogicAppsMonitorBlade/runid/%2Fsubscriptions%2F57b0d17a-5429-4dbb-8366-35c928e3ed94%2FresourceGroups%2FIBF-system%2Fproviders%2FMicrosoft.Logic%2Fworkflows%2F510-ibf-typhoon-prod%2Fruns%2F08584436713856550447602885638CU247)

__Replicate:__ When debugging with data from `20250915000000` as in the logic app run above, it was found that categories `CAT_NAMES` for typhoon are only from -1 to 4, meanwhile, `set_category` identifies a typhoon up to Cat 5 typhoon.

__Findings:__ Saffir-Simpson Hurricane Wind Scale in kn based on NOAA does have cat 5. While this categorization is based on PAGASA, who only classifies typhoon [max cat NOAA's cat 4](https://www.pagasa.dost.gov.ph/information/about-tropical-cyclone). 

__Fix:__ A cat 5 for typhoon is manually added.

